### PR TITLE
SCRUM-1163:  add okta authentication to example endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,8 +2,9 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.acme</groupId>
-  <artifactId>code-with-quarkus</artifactId>
+  <groupId>org.alliancegenome</groupId>
+  <artifactId>agr_mati</artifactId>
+  <name>AGR Minting and Tracking Identifiers (MaTI)</name>
   <version>1.0.0-SNAPSHOT</version>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
@@ -28,6 +29,10 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-jwt</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>

--- a/src/main/java/org/alliancegenome/mati/GreetingResource.java
+++ b/src/main/java/org/alliancegenome/mati/GreetingResource.java
@@ -1,4 +1,6 @@
-package org.acme;
+package org.alliancegenome.mati;
+
+import io.quarkus.security.Authenticated;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -9,6 +11,7 @@ import javax.ws.rs.core.MediaType;
 public class GreetingResource {
 
     @GET
+    @Authenticated
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
         return "Hello RESTEasy";

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,3 @@
 mp.jwt.verify.publickey.location=${OKTA_KEYS}
 mp.jwt.verify.issuer=${OKTA_ISSUER}
 
-# Working!
-#mp.jwt.verify.publickey.location=https://dev-1694418.okta.com/oauth2/default/v1/keys
-#mp.jwt.verify.issuer=https://dev-1694418.okta.com/oauth2/default

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+mp.jwt.verify.publickey.location=${OKTA_KEYS}
+mp.jwt.verify.issuer=${OKTA_ISSUER}
+
+# Working!
+#mp.jwt.verify.publickey.location=https://dev-1694418.okta.com/oauth2/default/v1/keys
+#mp.jwt.verify.issuer=https://dev-1694418.okta.com/oauth2/default


### PR DESCRIPTION
Tested:

with a .env file with something like:
OKTA_ISSUER=https://dev-1694418.okta.com/oauth2/default
OKTA_KEYS=https://dev-1694418.okta.com/oauth2/default/v1/keys
