### PR TITLE
SCRUM-2024: add subdomains for lit{resource,reference} and person

### DIFF
--- a/src/main/resources/db/migration/V0003__SCRUM-2024.sql
+++ b/src/main/resources/db/migration/V0003__SCRUM-2024.sql
@@ -1,0 +1,12 @@
+INSERT INTO subdomain (code, name, description)
+VALUES ('101', 'literature_reference', 'Literature Reference');
+CREATE SEQUENCE subdomain_literature_reference_seq;
+
+INSERT INTO subdomain (code, name, description)
+VALUES ('102', 'literature_resource', 'Literature Resource');
+CREATE SEQUENCE subdomain_literature_resource_seq;
+
+INSERT INTO subdomain (code, name, description)
+VALUES ('103', 'person', 'Person');
+CREATE SEQUENCE subdomain_person_seq;
+


### PR DESCRIPTION
The entries in the table subdomain and sequences to allow minting IDs for references, resources and persons.