### PR TITLE
SCRUM-2269 GH actions maintenance

### DIFF
--- a/.github/workflows/alpha-build-and-deploy.yml
+++ b/.github/workflows/alpha-build-and-deploy.yml
@@ -10,8 +10,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
-      - run: git fetch --prune --unshallow
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Declare some variables
         id: vars
         shell: bash
@@ -64,11 +65,9 @@ jobs:
             }
           ]
     - name: Check out repository code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
-        submodules: 'recursive'
-    - name: fetch all git tags
-      run: git fetch --prune --unshallow
+        fetch-depth: 0
     - name: Declare some variables
       id: vars
       shell: bash

--- a/.github/workflows/alpha-build-and-deploy.yml
+++ b/.github/workflows/alpha-build-and-deploy.yml
@@ -13,11 +13,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Declare some variables
+      - name: Store release tag in env
         id: vars
         shell: bash
         run: |
-          echo "##[set-output name=tagname;]$(git describe --tags)"
+          echo "tagname=$(git describe --tags)" >> $GITHUB_ENV
       # This step will configure environment variables to be used by all steps
       # involving AWS interaction further down
       - name: AWS credentials configuration
@@ -33,7 +33,7 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: agr_mati
-          IMAGE_TAG: ${{ steps.vars.outputs.tagname }}
+          IMAGE_TAG: ${{ env.tagname }}
         run: |
           docker build --build-arg OVERWRITE_VERSION=${IMAGE_TAG} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:${GITHUB_REF#refs/heads/}
@@ -68,19 +68,19 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Declare some variables
+    - name: Store release tag in env
       id: vars
       shell: bash
       run: |
-        echo "##[set-output name=tagname;]$(git describe --tags)"
+        echo "tagname=$(git describe --tags)" >> $GITHUB_ENV
     - name: Save mati app version to be deployed in EB env variables through config file
       run: |
-        sed -i.bak "s/0.0.0/${{ steps.vars.outputs.tagname }}/g" .ebextensions/version.config
+        sed -i.bak "s/0.0.0/${{ env.tagname }}/g" .ebextensions/version.config
         echo "Stored version config:"
         echo "----------------------"
         cat .ebextensions/version.config
     - name: Generate deployment package
-      run: zip -r ${{ steps.vars.outputs.tagname }}.zip docker-compose.yml .ebextensions/
+      run: zip -r ${{ env.tagname }}.zip docker-compose.yml .ebextensions/
     - name: Deploy to EB
       uses: einaregilsson/beanstalk-deploy@v14
       with:
@@ -88,8 +88,8 @@ jobs:
         aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         application_name: mati-app
         environment_name: mati-alpha
-        version_label: ${{ steps.vars.outputs.tagname }}
-        deployment_package: ${{ steps.vars.outputs.tagname }}.zip
+        version_label: ${{ env.tagname }}
+        deployment_package: ${{ env.tagname }}.zip
         use_existing_version_if_available: true
         region: us-east-1
     - name: Set COMMIT_MESSAGE
@@ -99,7 +99,7 @@ jobs:
       env:
         INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       with:
-        text: "Deployment of mati release ${{ steps.vars.outputs.tagname }} to alpha completed! :tada:"
+        text: "Deployment of mati release ${{ env.tagname }} to alpha completed! :tada:"
         attachments: |
           [
             {

--- a/.github/workflows/github-actions-PR-validation.yml
+++ b/.github/workflows/github-actions-PR-validation.yml
@@ -16,7 +16,7 @@ jobs:
           echo "Repository ${{ github.repository }}."
           echo "Trigger ref ${{ github.ref }}, base-ref ${{ github.base_ref }}, head_ref ${{ github.head_ref }}."
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Report files updated in PR
         run: |
           git fetch -q origin ${{ github.base_ref }} ${{ github.head_ref }}
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build docker image
         env:
           ECR_REPOSITORY: agr_mati

--- a/.github/workflows/github-release-build-and-deploy.yml
+++ b/.github/workflows/github-release-build-and-deploy.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: AWS credentials configuration
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v3
         with:
@@ -75,7 +75,7 @@ jobs:
             }
           ]
     - name: Check out repository code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Save mati app version to be deployed in EB env variables through config file
       run: |
         cat .ebextensions/version.config


### PR DESCRIPTION
GH actions has deprecated `actions/checkout@v2` and `set-output`. This PR replaces those.