### PR TITLE
SCRUM-2814: upgrade quarkus to 2.16.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
 		<quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-		<quarkus.platform.version>2.16.1.Final</quarkus.platform.version>
+		<quarkus.platform.version>2.16.6.Final</quarkus.platform.version>
 		<surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
 	</properties>
 


### PR DESCRIPTION
quarkus 3 is still on release candidates, this is a safe upgrade