### PR TITLE
SCRUM-3152: Upgrade quarkus to 3.2.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
 		<quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-		<quarkus.platform.version>3.2.0.Final</quarkus.platform.version>
+		<quarkus.platform.version>3.2.2.Final</quarkus.platform.version>
 		<surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
 	</properties>
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,7 @@ quarkus:
       generation: none
   swagger-ui:
     always-include: true
+  smallrye-openapi.management.enabled: false
 
 "%dev":
   quarkus:


### PR DESCRIPTION
`quarkus.smallrye-openapi.management.enabled: false`

is because swagger is now by default in the management interface:

https://quarkus.io/blog/quarkus-3-2-2-final-released/
