### PR TITLE
Fixed prod deployment notification

### DIFF
--- a/.github/workflows/github-release-build-and-deploy.yml
+++ b/.github/workflows/github-release-build-and-deploy.yml
@@ -56,26 +56,6 @@ jobs:
     needs: [build-release-image]
     runs-on: ubuntu-20.04
     steps:
-    - name: Slack Notification
-      uses: tokorom/action-slack-incoming-webhook@main
-      env:
-        INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      with:
-        text: "Auto Deployment to mati production initiated"
-        attachments: |
-          [
-            {
-              "color": "good",
-              "author_name": "${{ github.actor }}",
-              "author_icon": "${{ github.event.sender.avatar_url }}",
-              "fields": [
-                {
-                  "title": "GitHub Actions URL",
-                  "value": "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
-                }
-              ]
-            }
-          ]
     - name: Check out repository code
       uses: actions/checkout@v3
     - name: Save mati app version to be deployed in EB env variables through config file
@@ -97,6 +77,26 @@ jobs:
     needs: [generate-deployment-package]
     runs-on: ubuntu-20.04
     steps:
+    - name: Slack Notification
+      uses: tokorom/action-slack-incoming-webhook@main
+      env:
+        INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      with:
+        text: "Auto Deployment to mati production initiated"
+        attachments: |
+          [
+            {
+              "color": "good",
+              "author_name": "${{ github.actor }}",
+              "author_icon": "${{ github.event.sender.avatar_url }}",
+              "fields": [
+                {
+                  "title": "GitHub Actions URL",
+                  "value": "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
+                }
+              ]
+            }
+          ]
     - name: Fetch deployment package from cache
       uses: actions/cache@v3
       with:


### PR DESCRIPTION
Prod deployment notifications were currently being sent out on every deployment, including beta deployments. This is now fixed to only send notifications about prod deployments when actual prod deployment is about to happen.