### PR TITLE
refactor: return entity objects from IdentifierResource instead of Response

### DIFF
--- a/mati-api/src/main/java/org/alliancegenome/mati/api/controller/IdentifierResource.java
+++ b/mati-api/src/main/java/org/alliancegenome/mati/api/controller/IdentifierResource.java
@@ -1,21 +1,22 @@
 package org.alliancegenome.mati.api.controller;
 
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-import lombok.AllArgsConstructor;
 import org.alliancegenome.mati.api.configuration.ErrorResponse;
+import org.alliancegenome.mati.api.repository.SubdomainRepository;
+import org.alliancegenome.mati.api.repository.SubdomainSequenceRepository;
 import org.alliancegenome.mati.entity.Identifier;
 import org.alliancegenome.mati.entity.IdentifiersRange;
 import org.alliancegenome.mati.entity.SubdomainEntity;
 import org.alliancegenome.mati.interfaces.IdentifierResourceRESTInterface;
-import org.alliancegenome.mati.api.repository.SubdomainRepository;
-import org.alliancegenome.mati.api.repository.SubdomainSequenceRepository;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import lombok.AllArgsConstructor;
 
 /** Endpoints to mint AGR identifiers and get the last value of a counter  */
 @AllArgsConstructor
@@ -34,70 +35,63 @@ public class IdentifierResource implements IdentifierResourceRESTInterface {
 				String.format("%0" + 12 + "d", counter);
 	}
 
-	private Response makeResultResponse(SubdomainEntity subdomainEntity, Long counter) {
+	private WebApplicationException badRequest(String path, String message) {
+		ErrorResponse.ErrorMessage errorMessage = new ErrorResponse.ErrorMessage(path, message);
+		ErrorResponse errorResponse = new ErrorResponse(errorMessage);
+		return new WebApplicationException(Response.status(Response.Status.BAD_REQUEST).entity(errorResponse).build());
+	}
+
+	private Identifier makeResultResponse(SubdomainEntity subdomainEntity, Long counter) {
 		if (counter == -1L) {
-			ErrorResponse.ErrorMessage errorMessage = new ErrorResponse.ErrorMessage("identifier","Failure retrieving/incrementing the counter");
-			ErrorResponse errorResponse = new ErrorResponse(errorMessage);
-			return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse).build();
+			throw badRequest("identifier", "Failure retrieving/incrementing the counter");
 		} else {
 			Identifier identifier =  new Identifier(counter, subdomainEntity.getCode(), subdomainEntity.getName(),
 				formatCounter(counter, subdomainEntity));
-			return Response.ok().entity(identifier).build();
+			return identifier;
 		}
 	}
 
-	private Response makeResultResponse(SubdomainEntity subdomainEntity, Long firstValue, Long lastValue) {
+	private IdentifiersRange makeResultResponse(SubdomainEntity subdomainEntity, Long firstValue, Long lastValue) {
 		if ( firstValue==-1L || lastValue==-1L) {
-			ErrorResponse.ErrorMessage errorMessage = new ErrorResponse.ErrorMessage("identifier","Failure incrementing the counter");
-			ErrorResponse errorResponse = new ErrorResponse(errorMessage);
-			return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse).build();
+			throw badRequest("identifier", "Failure incrementing the counter");
 		} else {
 			Identifier first = new Identifier(firstValue, subdomainEntity.getCode(), subdomainEntity.getName(),
 				formatCounter(firstValue, subdomainEntity));
 			Identifier last = new Identifier(lastValue, subdomainEntity.getCode(), subdomainEntity.getName(),
 				formatCounter(lastValue, subdomainEntity));
 			IdentifiersRange identifiersRange = new IdentifiersRange(first, last);
-			return Response.ok().entity(identifiersRange).build();
+			return identifiersRange;
 		}
 	}
 
 
-	public Response get(String auth_header, String subdomain) {
+	public Identifier get(String auth_header, String subdomain) {
 		SubdomainEntity subdomainEntity = subdomainRepository.findByName(subdomain);
 		if (subdomainEntity == null) {
-			ErrorResponse.ErrorMessage errorMessage = new ErrorResponse.ErrorMessage("finder.get","ID subdomain " + subdomain +" not found");
-			ErrorResponse errorResponse = new ErrorResponse(errorMessage);
-			return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse).build();
+			throw badRequest("finder.get", "ID subdomain " + subdomain + " not found");
 		}
 		Long result = subdomainSequenceRepository.getValue(subdomainEntity);
 		return makeResultResponse(subdomainEntity, result);
 	}
 
-	public Response increment(String auth_header, String subdomain) {
+	public Identifier increment(String auth_header, String subdomain) {
 		SubdomainEntity subdomainEntity = subdomainRepository.findByName(subdomain);
 		if (subdomainEntity == null) {
-			ErrorResponse.ErrorMessage errorMessage = new ErrorResponse.ErrorMessage("finder.get","ID subdomain " + subdomain +" not found");
-			ErrorResponse errorResponse = new ErrorResponse(errorMessage);
-			return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse).build();
+			throw badRequest("finder.get", "ID subdomain " + subdomain + " not found");
 		}
 		Long result = subdomainSequenceRepository.increment(subdomainEntity);
 		return makeResultResponse(subdomainEntity, result);
 	}
 
-	public Response increment(String auth_header, String subdomain, int value) {
+	public IdentifiersRange increment(String auth_header, String subdomain, int value) {
 		SubdomainEntity subdomainEntity = subdomainRepository.findByName(subdomain);
 		if (subdomainEntity == null) {
-			ErrorResponse.ErrorMessage errorMessage = new ErrorResponse.ErrorMessage("identifier.post","ID subdomain " + subdomain +" not found");
-			ErrorResponse errorResponse = new ErrorResponse(errorMessage);
-			return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse).build();
+			throw badRequest("identifier.post", "ID subdomain " + subdomain + " not found");
 		}
 		long firstValue = subdomainSequenceRepository.getValue(subdomainEntity) + 1;
 		Long lastValue = subdomainSequenceRepository.increment(subdomainEntity, value);
 		if (firstValue == -1L || lastValue == -1L) {
-			ErrorResponse.ErrorMessage errorMessage = new ErrorResponse.ErrorMessage("identifier.post","failure incrementing subdomain " + subdomainEntity.getCode());
-			ErrorResponse errorResponse = new ErrorResponse(errorMessage);
-			return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse).build();
-
+			throw badRequest("identifier.post", "failure incrementing subdomain " + subdomainEntity.getCode());
 		}
 		return makeResultResponse(subdomainEntity, firstValue, lastValue);
 	}

--- a/mati-interfaces/pom.xml
+++ b/mati-interfaces/pom.xml
@@ -15,6 +15,10 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.alliancegenome</groupId>
+			<artifactId>mati-entity</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>jakarta.ws.rs</groupId>
 			<artifactId>jakarta.ws.rs-api</artifactId>
 		</dependency>

--- a/mati-interfaces/src/main/java/org/alliancegenome/mati/interfaces/IdentifierResourceRESTInterface.java
+++ b/mati-interfaces/src/main/java/org/alliancegenome/mati/interfaces/IdentifierResourceRESTInterface.java
@@ -1,13 +1,20 @@
 package org.alliancegenome.mati.interfaces;
 
-import jakarta.transaction.Transactional;
-import jakarta.validation.constraints.NotNull;
-import jakarta.ws.rs.*;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
+import org.alliancegenome.mati.entity.Identifier;
+import org.alliancegenome.mati.entity.IdentifiersRange;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import io.quarkus.security.Authenticated;
+import jakarta.transaction.Transactional;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 
 /** Endpoints to mint AGR identifiers and get the last value of a counter  */
@@ -23,7 +30,7 @@ public interface IdentifierResourceRESTInterface {
 	 * @return an HTTP response with the last identifier minted for the given subdomain */
 	@Authenticated
 	@GET
-	Response get(
+	Identifier get(
 		@NotNull(message = "Header does not have Authorization")
 		@HeaderParam("Authorization") String auth_header,
 		
@@ -37,7 +44,7 @@ public interface IdentifierResourceRESTInterface {
 	 * @return an HTTP response with the identifier minted  */
 	@Authenticated
 	@PUT
-	Response increment(
+	Identifier increment(
 		@NotNull(message = "Header does not have Authorization")
 		@HeaderParam("Authorization")
 		String auth_header,
@@ -55,7 +62,7 @@ public interface IdentifierResourceRESTInterface {
 	@Authenticated
 	@POST
 	@Transactional
-	Response increment(
+	IdentifiersRange increment(
 		@NotNull(message = "Header does not have Authorization")
 		@HeaderParam("Authorization")
 		String auth_header,


### PR DESCRIPTION
## Summary

Completes the refactor of `IdentifierResource` / `IdentifierResourceRESTInterface` so the REST interface methods return the concrete `Identifier` / `IdentifiersRange` objects instead of an opaque `Response`. Returning `Response` meant REST clients couldn't reconstruct the entity on the other side of JSON; the concrete return types let clients deserialize directly.

## Changes

- **`IdentifierResourceRESTInterface`** — `get`, `increment` (PUT), and `increment` (POST) now return `Identifier` / `IdentifiersRange` instead of `Response`. Removed the now-unused `Response` import.
- **`IdentifierResource`** — implementation updated to match the new signatures. Error paths now `throw` a `WebApplicationException` carrying a `BAD_REQUEST` `Response` with the `ErrorResponse` body, collapsed into a single `badRequest(path, message)` helper.
- **`mati-interfaces/pom.xml`** — added the `mati-entity` dependency so the interface can reference the returned types.

## Behavior preserved

A `WebApplicationException` whose `Response` carries an entity is used directly by JAX-RS, so clients still receive the same `400` + `ErrorResponse` JSON as before. Success paths are unchanged. The existing `ThrowableMapper` / `ConstraintViolationExceptionMapper` continue to handle everything else.

## Testing

- `mvn -pl mati-interfaces,mati-api -am clean compile` → BUILD SUCCESS
- Existing integration tests (`IdentifierResourceITCase`) assert success cases only (status 200, deserialize to `IdentifiersRange`) and are unaffected.