### PR TITLE
ci: post Slack notification when Maven Central publish completes

### DIFF
--- a/.github/workflows/github-release-build-and-deploy.yml
+++ b/.github/workflows/github-release-build-and-deploy.yml
@@ -52,6 +52,12 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+      - name: Slack Notification
+        uses: tokorom/action-slack-incoming-webhook@main
+        env:
+          INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          text: "Publication of ${{ github.event.release.tag_name }} to Maven Central completed! :tada:"
   generate-deployment-package:
     needs: [build-release-image]
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Adds a Slack notification step to the `build-deploy-maven-central-package` job in the release workflow, firing once the Maven Central publish finishes — mirroring the equivalent step in agr_curation. Reuses the existing `SLACK_WEBHOOK_URL` secret already used by the beta/production deploy notifications.