### PR TITLE
Tag EB instances with Team/Project via .ebextensions

### DIFF
--- a/.ebextensions/tags.config
+++ b/.ebextensions/tags.config
@@ -1,0 +1,17 @@
+# Tag the Elastic Beanstalk autoscaling group's launched instances with the
+# controlled-vocabulary Team/Project tags consumed by the
+# alliance-genome/agr_cost_analysis tag enforcer (cost attribution + ownership
+# routing). PropagateAtLaunch applies them to each instance on every deploy.
+# Mirrors the existing Tags block in loadbalancer.config and complements
+# environment-level tag propagation (LaunchTemplateTagPropagationEnabled).
+Resources:
+  AWSEBAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      Tags:
+        - Key: Team
+          Value: a-team
+          PropagateAtLaunch: true
+        - Key: Project
+          Value: mati
+          PropagateAtLaunch: true


### PR DESCRIPTION
## What
Adds `.ebextensions/tags.config` tagging the autoscaling group's instances with `Team=a-team` / `Project=mati` (`PropagateAtLaunch`), applied on every `eb deploy`.

## Why
These controlled-vocabulary tags drive the `alliance-genome/agr_cost_analysis` tag enforcer (cost attribution by Team + ownership routing). This replaces an earlier (closed) PR that added `--tags` to the Makefile `eb create` target — per @oblodgett that only runs at environment creation, whereas `.ebextensions` runs on every deploy.

Mirrors the existing `Tags` block in `loadbalancer.config`. Complements environment-level tag propagation (`LaunchTemplateTagPropagationEnabled: 'true'`), which already pushes the env tags onto instances/volumes; this codifies Team/Project in the repo so they persist across recreation.



@oblodgett — does overriding `AWSEBAutoScalingGroup` Tags look right to you, or would you prefer this on the launch template / a different resource?