### PR TITLE
SCRUM-6210: add laboratory subdomain migration

### DIFF
--- a/mati-api/src/main/resources/db/migration/V0004__SCRUM-6210.sql
+++ b/mati-api/src/main/resources/db/migration/V0004__SCRUM-6210.sql
@@ -1,0 +1,3 @@
+INSERT INTO subdomain (code, name, description)
+VALUES ('104', 'laboratory', 'Laboratory');
+CREATE SEQUENCE subdomain_laboratory_seq;


### PR DESCRIPTION
Adds Flyway migration `V0004__SCRUM-6210.sql` inserting the `laboratory` subdomain (code `104`) and its `subdomain_laboratory_seq` sequence, following the established V0003 pattern. Lands at `id 5`.